### PR TITLE
Corrected spelling of SandwichResponse class

### DIFF
--- a/src/02-services/Gateway/Controllers/SandwichController.cs
+++ b/src/02-services/Gateway/Controllers/SandwichController.cs
@@ -28,15 +28,15 @@ namespace Gateway.Controllers
     }
 
     [HttpPut]
-    public async Task<Messages.SandwichReponse> OnPut(Messages.SandwichRequest request)
+    public async Task<Messages.SandwichResponse> OnPut(Messages.SandwichRequest request)
     {
-      var result = new Messages.SandwichReponse();
+      var result = new Messages.SandwichResponse();
       using (var _queue = new Queue(_config["rabbitmq:url"], "customer"))
       {
         var reset = new AsyncManualResetEvent();
         _queue.StartListening((ea, message) =>
         {
-          var response = JsonConvert.DeserializeObject<Messages.SandwichReponse>(message);
+          var response = JsonConvert.DeserializeObject<Messages.SandwichResponse>(message);
           result.Success = response.Success;
           result.Description = $"SUCCESS: {response.Description}";
           result.Error = $"FAILED: {response.Error}";

--- a/src/02-services/Gateway/Messages/SandwichReponse.cs
+++ b/src/02-services/Gateway/Messages/SandwichReponse.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Messages
 {
-  public class SandwichReponse
+  public class SandwichResponse
   {
     public bool Success { get; set; }
     public string Description { get; set; }

--- a/src/02-services/Gateway/Pages/Sandwich.cshtml.cs
+++ b/src/02-services/Gateway/Pages/Sandwich.cshtml.cs
@@ -45,7 +45,7 @@ namespace Gateway.Pages
         var reset = new AsyncManualResetEvent();
         _queue.StartListening((ea, message) =>
         {
-          var response = JsonConvert.DeserializeObject<Messages.SandwichReponse>(message);
+          var response = JsonConvert.DeserializeObject<Messages.SandwichResponse>(message);
           if (response.Success)
             ReplyText = $"SUCCESS: {response.Description}";
           else

--- a/src/02-services/SandwichMaker/Messages/SandwichReponse.cs
+++ b/src/02-services/SandwichMaker/Messages/SandwichReponse.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Messages
 {
-  public class SandwichReponse
+  public class SandwichResponse
   {
     public bool Success { get; set; }
     public string Description { get; set; }

--- a/src/02-services/SandwichMaker/SandwichMaker.cs
+++ b/src/02-services/SandwichMaker/SandwichMaker.cs
@@ -134,7 +134,7 @@ namespace SandwichMaker
       {
         Console.WriteLine($"### SandwichMaker is done with {wip.CorrelationId}");
         _workInProgress.Remove(wip.CorrelationId);
-        _queue.SendReply(wip.ReplyTo, wip.CorrelationId, new Messages.SandwichReponse
+        _queue.SendReply(wip.ReplyTo, wip.CorrelationId, new Messages.SandwichResponse
         {
           Description = wip.GetDescription(),
           Success = !wip.Failed,


### PR DESCRIPTION
Noticed in your demo at VS Live that the Sandwich Response class was spelled SandwichReponse.  This pull request corrects the spelling. 